### PR TITLE
Fix compile error on Linux by changing a suspicious define.

### DIFF
--- a/qt_json_settings.h
+++ b/qt_json_settings.h
@@ -8,7 +8,7 @@
 # define JsonExport __declspec(dllimport)
 #endif
 #else
-#define QtJsonSettings
+#define JsonExport
 #endif
 
 #include <QSettings>


### PR DESCRIPTION
"QtJsonSettings" (a namespace) would be deleted and "JsonExport" would be left undefined. I suspect that the #define should have read JsonExport.